### PR TITLE
Keepjumps!

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ The parameters are as follows:
 #### Example mappings
 ```lua
 -- larry
-nvim_set_keymap("n", "<leader>P", "<CMD>SelectPreset<CR>", { noremap = true })
-nvim_set_keymap("n", "<leader>C", "<CMD>Configure<CR>", { noremap = true })
-nvim_set_keymap("n", "<leader>c", "<CMD>ToggleConfigureView<CR>", { noremap = true })
-nvim_set_keymap("n", "<leader>B", "<CMD>Build<CR>", { noremap = true })
-nvim_set_keymap("n", "<leader>b", "<CMD>ToggleBuildView<CR>", { noremap = true })
+nvim_set_keymap("n", "<leader>lP", "<CMD>SelectPreset<CR>", { noremap = true })
+nvim_set_keymap("n", "<leader>lC", "<CMD>Configure<CR>", { noremap = true })
+nvim_set_keymap("n", "<leader>lc", "<CMD>ToggleConfigureView<CR>", { noremap = true })
+nvim_set_keymap("n", "<leader>lB", "<CMD>Build<CR>", { noremap = true })
+nvim_set_keymap("n", "<leader>lb", "<CMD>ToggleBuildView<CR>", { noremap = true })
 ```
 
 ### Usage
@@ -64,5 +64,5 @@ In no particular order:
 - [ ] Goto file/line on compilation errors   
 - [ ] Colors in Configure View   
 - [ ] Colors in Build View   
-- [ ] Functionality for getting the current compilation target, and what progress it's at   
+- [ ] Functionality for getting the current compilation target, and what progress it's at, e.g. for use in |statusline|   
 - [ ] Display current preset in the status line?   

--- a/lua/larry/init.lua
+++ b/lua/larry/init.lua
@@ -143,7 +143,7 @@ Module.Configure = function()
 
 		if vim.api.nvim_get_current_buf() == buf then
 			vim.api.nvim_buf_set_option( buf, "modified", false )
-			vim.cmd( "normal! G" )
+			vim.cmd( "keepjumps normal! G" )
 		end
 	end
 	local on_exit = function( _, exit_code, _ )
@@ -156,7 +156,7 @@ Module.Configure = function()
 	end
 
 	vim.api.nvim_buf_set_option( buf, "modifiable", true )
-	vim.api.nvim_buf_call( _buffers.configure, function( _ ) vim.cmd( "normal! ggdG" ) end )
+	vim.api.nvim_buf_call( _buffers.configure, function( _ ) vim.cmd( "keepjumps normal! ggdG" ) end )
 	vim.api.nvim_buf_set_option( buf, "modifiable", false )
 
 	_jobs.configure = vim.fn.jobstart(
@@ -193,7 +193,7 @@ Module.Build = function()
 
 		if vim.api.nvim_get_current_buf() == buf then
 			vim.api.nvim_buf_set_option( buf, "modified", false )
-			vim.cmd( "normal! G" )
+			vim.cmd( "keepjumps normal! G" )
 		end
 	end
 	local on_exit = function( _, exit_code, _ )
@@ -206,7 +206,7 @@ Module.Build = function()
 	end
 
 	vim.api.nvim_buf_set_option( buf, "modifiable", true )
-	vim.api.nvim_buf_call( _buffers.build, function( _ ) vim.cmd( "normal! ggdG" ) end )
+	vim.api.nvim_buf_call( _buffers.build, function( _ ) vim.cmd( "keepjumps normal! ggdG" ) end )
 	vim.api.nvim_buf_set_option( buf, "modifiable", false )
 	_jobs.build = vim.fn.jobstart(
 		string.format( Module.config.build_command, Module.GetSelectedPreset() ),


### PR DESCRIPTION
Executing the "follow buffer" commands (`normal! G`) with `keepjumps` leaves the jumplist unaffected!    
This means that watching the commands execute does not mess with `<C-o>` and `<C-i>`...